### PR TITLE
fix: wildcard as indefinite

### DIFF
--- a/rust/s2-verification/src/history.rs
+++ b/rust/s2-verification/src/history.rs
@@ -534,10 +534,8 @@ async fn append(
             S2Error::Server(err) => {
                 match err.code.as_str() {
                     // Re: table on side-effect possibilities at <https://s2.dev/docs/api/error-codes>
-                    "request_timeout" | "other" | "storage" | "upstream_timeout" => {
-                        CallFinish::AppendIndefiniteFailure
-                    }
-                    _ => CallFinish::AppendDefiniteFailure,
+                    "rate_limited" | "hot_server" => CallFinish::AppendDefiniteFailure,
+                    _ => CallFinish::AppendIndefiniteFailure,
                 }
             }
             // Client errors and other errors are indefinite (might succeed on retry)


### PR DESCRIPTION
It's less risky to allow-list definite failures rather than the other way around. If s2 starts returning a new code therefore, we would assume the failure was indefinite.