### PR TITLE
chore: upgrade to rand 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,14 +116,14 @@ dependencies = [
 [[package]]
 name = "antithesis_sdk"
 version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18dbd97a5b6c21cc9176891cf715f7f0c273caf3959897f43b9bd1231939e675"
+source = "git+https://github.com/antithesishq/antithesis-sdk-rust?rev=6829a946e7e970cc743ffe17c3cee7d2bc25425a#6829a946e7e970cc743ffe17c3cee7d2bc25425a"
 dependencies = [
  "libc",
  "libloading",
  "linkme",
  "once_cell",
  "rand 0.8.6",
+ "rand_core 0.10.1",
  "rustc_version_runtime",
  "serde",
  "serde_json",
@@ -149,9 +149,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-compression"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -234,9 +234,9 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "blake3"
-version = "1.8.4"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -269,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -378,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "compression-core",
  "flate2",
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "constant_time_eq"
@@ -1119,9 +1119,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -1523,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -1550,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
@@ -1583,9 +1583,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s2-api"
-version = "0.28.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4d8f48bfbd2fdcb70e3311a6464cbee95be3e3da714667c3d68d84316bd83ce"
+checksum = "27e97053bed7c5fc92d7d62bf8c53737cbbce5b1ed87b00f723cc3f0e82109dc"
 dependencies = [
  "base64ct",
  "bytes",
@@ -1678,7 +1678,7 @@ dependencies = [
  "clap",
  "eyre",
  "futures",
- "rand 0.8.6",
+ "rand 0.10.1",
  "s2-sdk",
  "serde",
  "serde_json",

--- a/rust/s2-verification/Cargo.toml
+++ b/rust/s2-verification/Cargo.toml
@@ -14,8 +14,6 @@ serde = { version = "1.0.228", features = ["derive"] }
 tokio-stream = "0.1.18"
 futures = "0.3.32"
 serde_json = "1.0.149"
-antithesis_sdk = "0.2.8"
-# required for antithesis_sdk rand compatibility
-# needs to be 0.8 till it upgrades
-rand = "0.8"
+antithesis_sdk = { git = "https://github.com/antithesishq/antithesis-sdk-rust", rev = "6829a946e7e970cc743ffe17c3cee7d2bc25425a", default-features = false, features = ["full", "rand_v0_10"] }
+rand = "0.10"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }

--- a/rust/s2-verification/src/history.rs
+++ b/rust/s2-verification/src/history.rs
@@ -1,5 +1,5 @@
 use antithesis_sdk::random::AntithesisRng;
-use rand::Rng;
+use rand::RngExt;
 use s2_sdk::{
     S2Stream,
     types::{
@@ -47,7 +47,7 @@ pub fn generate_records(num_records: usize) -> eyre::Result<GeneratedBatch> {
     while records.len() < num_records && batch_bytes + PER_RECORD_OVERHEAD < MAX_BATCH_BYTES {
         let record_body_budget = MAX_BATCH_BYTES - batch_bytes - PER_RECORD_OVERHEAD;
 
-        let size = rng.gen_range(1..=record_body_budget);
+        let size = rng.random_range(1..=record_body_budget);
         let mut body = vec![0u8; size];
         rng.fill(&mut body[..]);
 
@@ -110,7 +110,7 @@ pub struct LabeledEvent {
 }
 
 fn random_op() -> Op {
-    match AntithesisRng.gen_range(0..3) {
+    match AntithesisRng.random_range(0..3) {
         0 => Op::Append,
         1 => Op::Read,
         2 => Op::CheckTail,
@@ -206,7 +206,7 @@ pub async fn fencing_token_client(
             let resp = match random_op() {
                 Op::Append => {
                     let GeneratedBatch { batch, last_xxh3 } =
-                        generate_records(AntithesisRng.gen_range(1..1000))?;
+                        generate_records(AntithesisRng.random_range(1..1000))?;
                     let fin = append(
                         history_tx.clone(),
                         stream.clone(),
@@ -273,7 +273,7 @@ pub async fn match_seq_num_client(
         let resp = match random_op() {
             Op::Append => {
                 let GeneratedBatch { batch, last_xxh3 } =
-                    generate_records(AntithesisRng.gen_range(1..1000))?;
+                    generate_records(AntithesisRng.random_range(1..1000))?;
                 let fin = append(
                     history_tx.clone(),
                     stream.clone(),
@@ -337,7 +337,7 @@ pub async fn client(
         match random_op() {
             Op::Append => {
                 let GeneratedBatch { batch, last_xxh3 } =
-                    generate_records(AntithesisRng.gen_range(1..1000))?;
+                    generate_records(AntithesisRng.random_range(1..1000))?;
                 let fin = append(
                     history_tx.clone(),
                     stream.clone(),


### PR DESCRIPTION
## Summary
- switch Antithesis RNG calls to rand 0.10's RngExt API
- replace gen_range usages with random_range
- update dependency metadata for rand 0.10 / antithesis_sdk rand_v0_10 support

## Test
- cargo test -p s2-verification