### PR TITLE
refactor!: adopt s2-sdk 0.34 APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,52 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aead"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
-dependencies = [
- "crypto-common",
- "generic-array",
-]
-
-[[package]]
-name = "aegis"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78412fa53e6da95324e8902c3641b3ff32ab45258582ea997eb9169c68ffa219"
-dependencies = [
- "cc",
- "softaes",
-]
-
-[[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "aes-gcm"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,18 +88,6 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-compression"
@@ -233,20 +175,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
-name = "blake3"
-version = "1.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq",
- "cpufeatures 0.3.0",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,18 +220,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
 ]
 
 [[package]]
@@ -363,17 +281,16 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+checksum = "79fcda08c33bb58b97008b2cdada6622500e949e060f5913361763121abd2416"
 dependencies = [
  "castaway",
  "cfg-if",
  "itoa",
- "rustversion",
- "ryu",
  "serde",
  "static_assertions",
+ "zmij",
 ]
 
 [[package]]
@@ -396,12 +313,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
-name = "constant_time_eq"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
-
-[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,15 +330,6 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -442,26 +344,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "typenum",
-]
-
-[[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher",
 ]
 
 [[package]]
@@ -506,17 +388,6 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -710,16 +581,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,16 +615,6 @@ dependencies = [
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
-]
-
-[[package]]
-name = "ghash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
-dependencies = [
- "opaque-debug",
- "polyval",
 ]
 
 [[package]]
@@ -903,88 +754,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "utf8_iter",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
-dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
-
-[[package]]
-name = "icu_properties"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
-
-[[package]]
-name = "icu_provider"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,27 +764,6 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "idna"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
 
 [[package]]
 name = "indenter"
@@ -1036,15 +784,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1055,6 +794,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -1134,12 +882,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "litemap"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1226,12 +968,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,27 +1035,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
-name = "polyval"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "opaque-debug",
- "universal-hash",
-]
-
-[[package]]
-name = "potential_utf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
-dependencies = [
- "zerovec",
-]
-
-[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,7 +1085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1565,17 +1280,17 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s2-api"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca965c408f0cd153ae0952bd5c6b6117041773421ccd0340f582e3a43968937"
+version = "0.30.10"
+source = "git+https://github.com/s2-streamstore/s2?rev=a298277bd0bec8c622faf69739068d0cd5995774#a298277bd0bec8c622faf69739068d0cd5995774"
 dependencies = [
  "base64ct",
  "bytes",
  "compact_str",
  "flate2",
- "futures",
+ "futures-core",
+ "futures-util",
  "http",
- "itertools",
+ "itertools 0.15.0",
  "mime",
  "prost",
  "s2-common",
@@ -1590,14 +1305,10 @@ dependencies = [
 
 [[package]]
 name = "s2-common"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc61e655b6fa10d0c9ce905dce2d8b8ea7c70a415866485253331ffa54a708c2"
+version = "0.41.1"
+source = "git+https://github.com/s2-streamstore/s2?rev=a298277bd0bec8c622faf69739068d0cd5995774#a298277bd0bec8c622faf69739068d0cd5995774"
 dependencies = [
- "aegis",
- "aes-gcm",
  "base64ct",
- "blake3",
  "bytes",
  "compact_str",
  "enumset",
@@ -1612,15 +1323,15 @@ dependencies = [
 
 [[package]]
 name = "s2-sdk"
-version = "0.31.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "341e00f248a685c53e65a6889aabbfcefb9035abb69730e8b3335aeea89b8d13"
+version = "0.33.0"
+source = "git+https://github.com/s2-streamstore/s2?rev=a298277bd0bec8c622faf69739068d0cd5995774#a298277bd0bec8c622faf69739068d0cd5995774"
 dependencies = [
  "async-compression",
  "async-stream",
  "async-trait",
  "bytes",
- "futures",
+ "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -1644,7 +1355,6 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
- "url",
  "urlencoding",
  "uuid",
 ]
@@ -1830,18 +1540,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "softaes"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef461faaeb36c340b6c887167a9054a034f6acfc50a014ead26a02b4356b3de"
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,17 +1587,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1960,16 +1647,6 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tinystr"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
-dependencies = [
- "displaydoc",
- "zerovec",
 ]
 
 [[package]]
@@ -2132,12 +1809,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "typenum"
-version = "1.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,44 +1821,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "universal-hash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
-dependencies = [
- "crypto-common",
- "subtle",
-]
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "url"
-version = "2.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
-]
-
-[[package]]
 name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -2212,12 +1855,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -2514,39 +2151,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "writeable"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
 name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
-
-[[package]]
-name = "yoke"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
-dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
 
 [[package]]
 name = "zerocopy"
@@ -2569,64 +2177,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerofrom"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-
-[[package]]
-name = "zerotrie"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,8 +1280,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s2-api"
-version = "0.30.10"
-source = "git+https://github.com/s2-streamstore/s2?rev=e7268fea95befce79ee743c20306655bfde5354e#e7268fea95befce79ee743c20306655bfde5354e"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac6483f24dde60844467a00c2127541c496d668a94f623b310b506062f80f46"
 dependencies = [
  "base64ct",
  "bytes",
@@ -1306,7 +1307,8 @@ dependencies = [
 [[package]]
 name = "s2-common"
 version = "0.41.1"
-source = "git+https://github.com/s2-streamstore/s2?rev=e7268fea95befce79ee743c20306655bfde5354e#e7268fea95befce79ee743c20306655bfde5354e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa0280e065047540a00a7f99a16ed7b171f70b9ffbcf5f79b56fb21df23e3a1"
 dependencies = [
  "base64ct",
  "bytes",
@@ -1323,8 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "s2-sdk"
-version = "0.33.0"
-source = "git+https://github.com/s2-streamstore/s2?rev=e7268fea95befce79ee743c20306655bfde5354e#e7268fea95befce79ee743c20306655bfde5354e"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1b95898afe474b26fcfb0de6d0a4403042e421d2e8c5ffa8083ec3379474ea6"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 [[package]]
 name = "s2-api"
 version = "0.30.10"
-source = "git+https://github.com/s2-streamstore/s2?rev=a298277bd0bec8c622faf69739068d0cd5995774#a298277bd0bec8c622faf69739068d0cd5995774"
+source = "git+https://github.com/s2-streamstore/s2?rev=e7268fea95befce79ee743c20306655bfde5354e#e7268fea95befce79ee743c20306655bfde5354e"
 dependencies = [
  "base64ct",
  "bytes",
@@ -1306,7 +1306,7 @@ dependencies = [
 [[package]]
 name = "s2-common"
 version = "0.41.1"
-source = "git+https://github.com/s2-streamstore/s2?rev=a298277bd0bec8c622faf69739068d0cd5995774#a298277bd0bec8c622faf69739068d0cd5995774"
+source = "git+https://github.com/s2-streamstore/s2?rev=e7268fea95befce79ee743c20306655bfde5354e#e7268fea95befce79ee743c20306655bfde5354e"
 dependencies = [
  "base64ct",
  "bytes",
@@ -1324,7 +1324,7 @@ dependencies = [
 [[package]]
 name = "s2-sdk"
 version = "0.33.0"
-source = "git+https://github.com/s2-streamstore/s2?rev=a298277bd0bec8c622faf69739068d0cd5995774#a298277bd0bec8c622faf69739068d0cd5995774"
+source = "git+https://github.com/s2-streamstore/s2?rev=e7268fea95befce79ee743c20306655bfde5354e#e7268fea95befce79ee743c20306655bfde5354e"
 dependencies = [
  "async-compression",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,3 @@ members = [
     "rust/s2-verification",
 ]
 resolver = "2"
-
-[patch.crates-io]
-# Remove this patch after the breaking SDK APIs are available in a release.
-s2-sdk = { git = "https://github.com/s2-streamstore/s2", rev = "e7268fea95befce79ee743c20306655bfde5354e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,5 @@ members = [
 resolver = "2"
 
 [patch.crates-io]
-# Remove this patch after the granular error API is available in a released SDK.
-s2-sdk = { git = "https://github.com/s2-streamstore/s2", rev = "a298277bd0bec8c622faf69739068d0cd5995774" }
+# Remove this patch after the breaking SDK APIs are available in a release.
+s2-sdk = { git = "https://github.com/s2-streamstore/s2", rev = "e7268fea95befce79ee743c20306655bfde5354e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,7 @@ members = [
     "rust/s2-verification",
 ]
 resolver = "2"
+
+[patch.crates-io]
+# Remove this patch after the granular error API is available in a released SDK.
+s2-sdk = { git = "https://github.com/s2-streamstore/s2", rev = "a298277bd0bec8c622faf69739068d0cd5995774" }

--- a/rust/s2-verification/Cargo.toml
+++ b/rust/s2-verification/Cargo.toml
@@ -12,7 +12,7 @@ futures = "0.3.32"
 # required for antithesis_sdk rand compatibility
 # needs to be 0.8 till it upgrades
 rand = "0.8"
-s2-sdk = ">=0.29, <1"
+s2-sdk = ">=0.34, <1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 tokio = { version = "1.52.3", features = ["full"] }

--- a/rust/s2-verification/src/bin/collect-history.rs
+++ b/rust/s2-verification/src/bin/collect-history.rs
@@ -4,9 +4,10 @@ use futures::StreamExt;
 use futures::stream::FuturesUnordered;
 use s2_sdk::{
     S2,
+    error::ErrorCode,
     types::{
         AppendRetryPolicy, BasinName, CreateStreamInput, RetryConfig, S2Config, S2Endpoints,
-        S2Error, StreamName,
+        StreamName,
     },
 };
 use s2_verification::history::{
@@ -89,7 +90,12 @@ async fn main() -> eyre::Result<()> {
         .await
     {
         Ok(_) => true,
-        Err(S2Error::Server(e)) if e.code.as_str() == "resource_already_exists" => true,
+        Err(e)
+            if e.server_error().and_then(|error| error.known_code())
+                == Some(ErrorCode::ResourceAlreadyExists) =>
+        {
+            true
+        }
         Err(e) => return Err(eyre!(e)),
     };
 

--- a/rust/s2-verification/src/history.rs
+++ b/rust/s2-verification/src/history.rs
@@ -2,9 +2,10 @@ use antithesis_sdk::random::AntithesisRng;
 use rand::Rng;
 use s2_sdk::{
     S2Stream,
+    error::{ReadError, ReadSessionError},
     types::{
         AppendInput, AppendRecord, AppendRecordBatch, CommandRecord, FencingToken, MeteredBytes,
-        ReadBatch, ReadFrom, ReadInput, ReadLimits, ReadStart, ReadStop, S2Error,
+        ReadBatch, ReadFrom, ReadInput, ReadLimits, ReadStart, ReadStop,
     },
 };
 use serde::Serialize;
@@ -407,7 +408,7 @@ pub async fn client(
 
 #[tracing::instrument(level = Level::TRACE, skip_all)]
 async fn resolve_read_tail(
-    mut stream: impl Stream<Item = Result<ReadBatch, S2Error>> + Unpin,
+    mut stream: impl Stream<Item = Result<ReadBatch, ReadSessionError>> + Unpin,
 ) -> eyre::Result<CallFinish> {
     let mut tail = 0;
     let mut stream_hash = 0;
@@ -469,7 +470,7 @@ async fn read_session(
         }
         // Reading from seq_num 0 on an empty stream is reported as unwritten;
         // that is still an authoritative observation of an empty stream.
-        Err(S2Error::ReadUnwritten(pos)) if pos.seq_num == 0 => {
+        Err(ReadSessionError::Read(ReadError::ReadUnwritten(pos))) if pos.seq_num == 0 => {
             trace!("read_session on empty stream");
             CallFinish::ReadSuccess {
                 tail: 0,
@@ -574,24 +575,8 @@ async fn append(
         Ok(ack) => CallFinish::AppendSuccess {
             tail: ack.end.seq_num,
         },
-        Err(e) => match &e {
-            // Validation errors are definite failures
-            S2Error::Validation(_) => CallFinish::AppendDefiniteFailure,
-            // Append condition failures (fencing token mismatch, seq num mismatch) are definite
-            S2Error::AppendConditionFailed(_) => CallFinish::AppendDefiniteFailure,
-            // Server errors - check the code for definite vs indefinite
-            S2Error::Server(err) => {
-                match err.code.as_str() {
-                    // Re: table on side-effect possibilities at <https://s2.dev/docs/api/error-codes>
-                    "rate_limited" | "hot_server" | "transaction_conflict" => {
-                        CallFinish::AppendDefiniteFailure
-                    }
-                    _ => CallFinish::AppendIndefiniteFailure,
-                }
-            }
-            // Client errors and other errors are indefinite (might succeed on retry)
-            _ => CallFinish::AppendIndefiniteFailure,
-        },
+        Err(e) if e.has_no_side_effects() => CallFinish::AppendDefiniteFailure,
+        Err(_) => CallFinish::AppendIndefiniteFailure,
     };
 
     match finish {
@@ -629,7 +614,9 @@ pub async fn read_all_record_hashes(stream: &S2Stream) -> eyre::Result<(u64, Vec
 
     let mut session = match read_session {
         Ok(session) => session,
-        Err(S2Error::ReadUnwritten(pos)) if pos.seq_num == 0 => return Ok((0, Vec::new())),
+        Err(ReadSessionError::Read(ReadError::ReadUnwritten(pos))) if pos.seq_num == 0 => {
+            return Ok((0, Vec::new()));
+        }
         Err(e) => return Err(eyre::eyre!(e)),
     };
 

--- a/rust/s2-verification/src/history.rs
+++ b/rust/s2-verification/src/history.rs
@@ -5,7 +5,7 @@ use s2_sdk::{
     error::{ReadError, ReadSessionError},
     types::{
         AppendInput, AppendRecord, AppendRecordBatch, CommandRecord, FencingToken, MeteredBytes,
-        ReadBatch, ReadFrom, ReadInput, ReadLimits, ReadStart, ReadStop,
+        ReadBatch, ReadFrom, ReadInput, ReadLimits, ReadSessionConfig, ReadStart, ReadStop,
     },
 };
 use serde::Serialize;
@@ -460,6 +460,7 @@ async fn read_session(
                 .with_start(ReadStart::new().with_from(ReadFrom::SeqNum(0)))
                 // Read must include a limit, otherwise we will enter a tailing session.
                 .with_stop(ReadStop::new().with_limits(ReadLimits::new().with_count(usize::MAX))),
+            ReadSessionConfig::default(),
         )
         .await;
 
@@ -609,6 +610,7 @@ pub async fn read_all_record_hashes(stream: &S2Stream) -> eyre::Result<(u64, Vec
                 .with_start(ReadStart::new().with_from(ReadFrom::SeqNum(0)))
                 // Read must include a limit, otherwise we will enter a tailing session.
                 .with_stop(ReadStop::new().with_limits(ReadLimits::new().with_count(usize::MAX))),
+            ReadSessionConfig::default(),
         )
         .await;
 


### PR DESCRIPTION
## Summary

- migrate read-session handling from the removed `S2Error` umbrella to `ReadSessionError` and `ReadError`
- classify append outcomes with `AppendError::has_no_side_effects()` instead of matching server-code strings
- use the typed `ErrorCode` accessor when accepting an already-existing stream
- pass `ReadSessionConfig::default()` at both read-session call sites, preserving the previous budgeted retry behavior
- raise the supported `s2-sdk` floor from `0.29` to `0.34` and use the crates.io release without a git patch

## Changelog notes

- `s2-sdk >=0.29, <1 -> >=0.34, <1`: 0.34 replaces `S2Error` with operation-specific error types and adds explicit read-session retry configuration. Sources: [s2-sdk 0.34.0](https://crates.io/crates/s2-sdk/0.34.0), [release PR](https://github.com/s2-streamstore/s2/pull/672).
- Lockfile resolution moves `s2-sdk 0.33.0`, `s2-api 0.30.10`, and `s2-common 0.41.1` from the temporary git source to published crates (`s2-sdk 0.34.0`, `s2-api 0.31.0`, and `s2-common 0.41.1`).

## Risk notes

- This is a breaking SDK migration, but the affected verification call sites are fully adapted to the typed errors and new method signature.
- `ReadSessionConfig::default()` retains the former bounded-retry behavior.
- The dependency lower bound is raised because the migrated code does not compile against SDK versions before 0.34.

## Validation

- `cargo metadata --locked --format-version 1`: passed
- `cargo fmt --all -- --check`: passed
- `cargo clippy --all-targets --all-features -- -D warnings`: passed
- `cargo test --all-features --workspace`: passed